### PR TITLE
Issue 240 handle user logout more nicely

### DIFF
--- a/client/src/components/LoginModal.vue
+++ b/client/src/components/LoginModal.vue
@@ -60,7 +60,7 @@ const submitForm = async () => {
       messageStore.showMessage('Success', 'Login success.', 'success')
       closeDialog()
     } else if (loginResult === false) {
-      messageStore.showMessage('Error', 'An unexpected error occured. Please try again.', 'error')
+      messageStore.handleUnexpectedError(undefined, true)
     } else {
       errorMessage.value = 'No user with the given username and password was found.'
     }

--- a/client/src/components/RegisterModal.vue
+++ b/client/src/components/RegisterModal.vue
@@ -154,16 +154,12 @@ const submitForm = async () => {
     if (verificationResult === true) {
       setCurrentPage('confirmation')
     } else if (verificationResult === false) {
-      messageStore.showMessage(
-        'Error',
-        'An unexpected error occured while attempting to verify your email',
-        'error',
-      )
+      messageStore.handleUnexpectedError(undefined, false)
     } else {
       messageStore.showMessage('Error', verificationResult, 'warning')
     }
   } else if (registrationResult === false) {
-    messageStore.showMessage('Error', 'An unexpected error occured. Please try again.', 'error')
+    messageStore.handleUnexpectedError(undefined, true)
   } else {
     const nameMapping: Array<{
       serverName: keyof BackendUser

--- a/client/src/stores/message.ts
+++ b/client/src/stores/message.ts
@@ -26,6 +26,18 @@ export const useMessageStore = defineStore('message', () => {
     content.value = ''
   }
 
+  function handleUnexpectedError(sessionExpired: boolean | undefined, suggestRetry: boolean) {
+    if (sessionExpired) {
+      showMessage('Session Expired', 'Your session expired, so you have been logged out', 'warning')
+    } else {
+      showMessage(
+        'Error',
+        `An unexpected error occurred.${suggestRetry ? ' Please try again.' : ''}`,
+        'error',
+      )
+    }
+  }
+
   return {
     isOpen,
     title,
@@ -33,5 +45,6 @@ export const useMessageStore = defineStore('message', () => {
     type,
     showMessage,
     closeMessage,
+    handleUnexpectedError,
   }
 })

--- a/client/src/types/other.ts
+++ b/client/src/types/other.ts
@@ -1,0 +1,4 @@
+import { AxiosError } from 'axios'
+export type ExtendedAxiosError = AxiosError & {
+  config: { token_refreshed?: boolean; session_expired?: boolean }
+}

--- a/client/src/utils/server.ts
+++ b/client/src/utils/server.ts
@@ -1,5 +1,6 @@
-import axios, { AxiosError } from 'axios'
+import axios from 'axios'
 import { useUserStore } from '@/stores/user'
+import type { ExtendedAxiosError } from '@/types/other'
 
 const server = axios.create({
   baseURL: `${import.meta.env.VITE_BACKEND_URL}/api`,
@@ -25,7 +26,7 @@ server.interceptors.response.use(
   (response) => {
     return response
   },
-  async (error: AxiosError & { config: { token_refreshed?: boolean } }) => {
+  async (error: ExtendedAxiosError) => {
     const userStore = useUserStore()
     if (error.response?.status === 401 && userStore.refreshToken && !error.config.token_refreshed) {
       try {
@@ -39,16 +40,18 @@ server.interceptors.response.use(
         if (response.data.access) {
           userStore.accessToken = response.data.access
           // Mark the token as already refreshed
-          // The importance of this is that it avoids an infinite loop of refresh attemps if
+          // The importance of this is that it avoids an infinite loop of refresh attempts if
           // the refresh endpoint is broken yet keeps returning a 401 status code
           error.config.token_refreshed = true
           return server(error.config)
         }
         // if the response doesn't contain an access token for some reason, then logout
         userStore.logout()
+        error.config.session_expired = true
       } catch {
-        // This will run if the call to the token endpoint is unsucessful (meaning the refresh token is invalid, so a login is required)
+        // This will run if the call to the token endpoint is unsuccessful (meaning the refresh token is invalid, so a login is required)
         userStore.logout()
+        error.config.session_expired = true
       }
     }
 

--- a/client/src/views/AdminView.vue
+++ b/client/src/views/AdminView.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import WaveBanner from '@/components/WaveBanner.vue'
 import { useMessageStore } from '@/stores/message'
+import type { ExtendedAxiosError } from '@/types/other'
 import server from '@/utils/server'
-import type { AxiosError } from 'axios'
 import { ref } from 'vue'
 
 const isValid = ref(false)
@@ -43,7 +43,7 @@ function updateBingo() {
       )
       challengeIds.value = [...initialContents]
     })
-    .catch((error: AxiosError) => {
+    .catch((error: ExtendedAxiosError) => {
       const challenges = (error.response?.data as { challenges?: [string, ...string[]] })
         ?.challenges
 
@@ -53,7 +53,7 @@ function updateBingo() {
           ? `There does not exist a challenge with id ${invalidId}.`
           : challenges[0]
       } else {
-        messageStore.showMessage('Error', 'An unexpected error occurred', 'error')
+        messageStore.handleUnexpectedError(error.config?.session_expired, false)
       }
     })
 }

--- a/client/src/views/BlingoView.vue
+++ b/client/src/views/BlingoView.vue
@@ -9,6 +9,7 @@ import WaveBanner from '@/components/WaveBanner.vue'
 import server from '@/utils/server'
 import { useMessageStore } from '@/stores/message'
 import type { BingoData, BingoType } from '@/types/bingo'
+import type { ExtendedAxiosError } from '@/types/other'
 
 const { mdAndDown } = useDisplay()
 const userStore = useUserStore()
@@ -46,8 +47,8 @@ const fetchBingoGrid = async () => {
       })
       isLoading.value = false
     })
-    .catch(() => {
-      messageStore.showMessage('Error', 'Unexpected occured while fetching challenges.', 'error')
+    .catch((error: ExtendedAxiosError) => {
+      messageStore.handleUnexpectedError(error.config?.session_expired, false)
     })
 }
 

--- a/client/src/views/ForgotPasswordView.vue
+++ b/client/src/views/ForgotPasswordView.vue
@@ -33,11 +33,7 @@ const resetPassword = async () => {
       router.replace('/')
       modalStore.openLogin()
     } else if (resetResult === false) {
-      messageStore.showMessage(
-        'Error',
-        'An unexpected error occurred while trying to reset your password.',
-        'error',
-      )
+      messageStore.handleUnexpectedError(undefined, false)
     } else if (resetResult === 'invalid link') {
       paramsInvalid.value = true
       messageStore.showMessage('Error', 'Invalid password reset link', 'error')

--- a/client/src/views/PlaceHolderview.vue
+++ b/client/src/views/PlaceHolderview.vue
@@ -1,5 +1,0 @@
-<template>
-  <div>
-    <p>Placeholder for {{ $route.name }}</p>
-  </div>
-</template>

--- a/client/src/views/PreferenceView.vue
+++ b/client/src/views/PreferenceView.vue
@@ -6,8 +6,8 @@ import avatarPaths from '@/utils/avatar'
 import { useUserStore } from '@/stores/user'
 import type { User } from '@/types/user'
 import server from '@/utils/server'
-import { AxiosError } from 'axios'
 import { useMessageStore } from '@/stores/message'
+import type { ExtendedAxiosError } from '@/types/other'
 
 const { xs } = useDisplay()
 const userStore = useUserStore()
@@ -50,7 +50,7 @@ const handleApply = () => {
       isEditing.value = false
       messageStore.showMessage('Success', 'Preferences successfully changed!', 'success')
     })
-    .catch((error: AxiosError) => {
+    .catch((error: ExtendedAxiosError) => {
       if (
         error.response &&
         error.response.status === 400 &&
@@ -58,7 +58,7 @@ const handleApply = () => {
       ) {
         bioError.value = 'Please enter a bio with at most 300 characters'
       } else {
-        messageStore.showMessage('Error', 'An unexpected error occured. Please try again.', 'error')
+        messageStore.handleUnexpectedError(error.config?.session_expired, false)
       }
     })
     .finally(() => {

--- a/client/src/views/ProfileView.vue
+++ b/client/src/views/ProfileView.vue
@@ -9,8 +9,8 @@ import WaveBanner from '@/components/WaveBanner.vue'
 import avatarPaths from '@/utils/avatar'
 import server from '@/utils/server'
 import { useMessageStore } from '@/stores/message'
-import type { AxiosError } from 'axios'
 import type { Challenge, UserProfile } from '@/types/profile'
+import type { ExtendedAxiosError } from '@/types/other'
 
 const props = defineProps<{
   username?: string
@@ -51,7 +51,7 @@ const initializeProfile = () => {
       permission.value = res.data.permission
       loading.value = false
     })
-    .catch((error: AxiosError) => {
+    .catch((error: ExtendedAxiosError) => {
       loading.value = false
       if (error.response?.status === 404) {
         messageStore.showMessage(
@@ -60,11 +60,7 @@ const initializeProfile = () => {
           'warning',
         )
       } else {
-        messageStore.showMessage(
-          'Error',
-          'Unexpected occured while fetching user profile.',
-          'error',
-        )
+        messageStore.handleUnexpectedError(error.config?.session_expired, false)
       }
     })
 }


### PR DESCRIPTION
## Change Summary
- If there is an error due to the user's refresh token expiring, the page will show a warning explaining that the user has been logged out rather than just saying "unexpected error".

### Change Form
**Fill this up (NA if not available). If a certain criteria is not met, can you please give a reason.**

- [ ] The pull request title has an issue number
- [ ] The change works by "Smoke testing" or quick testing
- [ ] The change has tests
- [ ] The change has documentation

## Other Information
**[Is there anything in particular in the review that I should be aware of?]**

# Related issue

- Resolve #240