### PR TITLE
add signals to delete files

### DIFF
--- a/client/src/views/EmailVerificationView.vue
+++ b/client/src/views/EmailVerificationView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { defineProps, onMounted, ref } from 'vue'
+import { onMounted, ref } from 'vue'
 import { useMessageStore } from '@/stores/message'
 import { useRouter } from 'vue-router'
 import { useUserStore } from '@/stores/user'

--- a/client/src/views/ForgotPasswordView.vue
+++ b/client/src/views/ForgotPasswordView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { defineProps, onMounted, ref } from 'vue'
+import { onMounted, ref } from 'vue'
 import { useMessageStore } from '@/stores/message'
 import { useUserStore } from '@/stores/user'
 import { useModalStore } from '@/stores/modal'

--- a/server/bingo/apps.py
+++ b/server/bingo/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class BingoConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "bingo"
+
+    def ready(self):
+        import bingo.signals

--- a/server/bingo/apps.py
+++ b/server/bingo/apps.py
@@ -6,4 +6,4 @@ class BingoConfig(AppConfig):
     name = "bingo"
 
     def ready(self):
-        import bingo.signals
+        import bingo.signals  # noqa

--- a/server/bingo/signals.py
+++ b/server/bingo/signals.py
@@ -1,0 +1,38 @@
+from .models import TileInteraction
+import os
+from django.dispatch import receiver
+from django.db.models.signals import post_delete, pre_save
+
+# modified from https://stackoverflow.com/a/16041527
+
+
+@receiver(post_delete, sender=TileInteraction)
+def auto_delete_file_on_delete(sender, instance, **kwargs):
+    """
+    Deletes file from filesystem
+    when corresponding `TileInteraction` object is deleted.
+    """
+    if instance.image:
+        if os.path.isfile(instance.image.path):
+            os.remove(instance.image.path)
+
+
+@receiver(pre_save, sender=TileInteraction)
+def auto_delete_file_on_change(sender, instance, **kwargs):
+    """
+    Deletes old file from filesystem
+    when corresponding `TileInteraction` object is updated
+    with new file.
+    """
+    if not instance.pk:
+        return False
+
+    try:
+        old_image = TileInteraction.objects.get(pk=instance.pk).image
+    except TileInteraction.DoesNotExist:
+        return False
+
+    new_image = instance.image
+    if old_image and not old_image == new_image:
+        if os.path.isfile(old_image.path):
+            os.remove(old_image.path)


### PR DESCRIPTION
## Change Summary
If the image in a ``TileInteraction`` instances is deleted or changed, the old image file gets deleted. Previously, the result of deleting a ``TileInteraction`` instance would be that the image's path is no longer stored in the db, but the image file still exists in the file system. This PR will make sure the file gets deleted.

### Change Form
**Fill this up (NA if not available). If a certain criteria is not met, can you please give a reason.**

- [ ] The pull request title has an issue number
- [x] The change works by "Smoke testing" or quick testing
- [ ] The change has tests
- [ ] The change has documentation

## Other Information
**[Is there anything in particular in the review that I should be aware of?]**